### PR TITLE
Fix atoum configuration

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -23,4 +23,6 @@ $cliReport
     ->addField($coverageField, array(atoum\runner::runStop))
 ;
 
+$runner->setBootstrapFile('test/bootstrap.php');
+
 $runner->addReport($cliReport);

--- a/bin/test
+++ b/bin/test
@@ -1,2 +1,2 @@
 #!/bin/sh
-vendor/bin/atoum -bf test/bootstrap.php --loop $*
+vendor/bin/atoum --loop $*


### PR DESCRIPTION
This commit fixes the atoum configuration so we can use the following commands to launch tests :
- bin/test which launches test in loop mode and can take additional arguments like `--debug`
- php vendor/mageekguy/atoum/bin/atoum --test-all : which is a more commonway to launch tests (using the _standard_ command)

So this PR lets us use one of these two commands which can be very usefull when using CI like Coconut-CI or Travis-CI.

For example : Coconut-CI has some predefined configuration to run atoum tests and it assumes that the test suite can be launched with the _standard_ command. Otherwise, you would have to define a custom build script which is more complicated ;)
