### PR TITLE
move atoum to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/yaml": "~2.3",
-        "atoum/atoum": "dev-master#c6ec75d4cf132728e80ec8ed1470b83cb53fc1c9"
+        "symfony/yaml": "~2.3"
+    },
+    "require-dev": {
+        "atoum/atoum": "dev-master#c6ec75d4cf132728e80ec8ed1470b83cb53fc1c9"	
     }
 }


### PR DESCRIPTION
there is no need for atoum unless for tests. so move that to require-dev is good idea.  
Please register this package in packagist. 
