### PR TITLE
Allow non-scalar values to be validated in Enum

### DIFF
--- a/src/RomaricDrigon/MetaYaml/NodeValidator/EnumNodeValidator.php
+++ b/src/RomaricDrigon/MetaYaml/NodeValidator/EnumNodeValidator.php
@@ -33,7 +33,11 @@ class EnumNodeValidator extends NodeValidator
         }
 
         if (! in_array($data, $haystack, $strict)) {
-            throw new NodeValidatorException($name, "The value '$data' is not allowed for node '$name'");
+            if (is_scalar($data)) {
+                throw new NodeValidatorException($name, "The value '$data' is not allowed for node '$name'");
+            }
+
+            throw new NodeValidatorException($name, "The value " . var_export($data, true) . " is not allowed for node '$name'");
         }
 
         return true;


### PR DESCRIPTION
If the user specified an array in an enum choice, then a PHP "Array to string" conversion error was given instead of the expected Exception.
